### PR TITLE
Bumped all download/upload-artifact actions to be > v3.

### DIFF
--- a/.github/workflows/mean_bean_ci.yml
+++ b/.github/workflows/mean_bean_ci.yml
@@ -18,7 +18,7 @@ jobs:
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: cross-${{ matrix.platform }}
           path: ${{ steps.cross.outputs.install_path }}
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 50
 
       - name: Download Cross
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: cross-linux-musl
           path: /tmp/

--- a/.github/workflows/mean_bean_deploy.yml
+++ b/.github/workflows/mean_bean_deploy.yml
@@ -28,7 +28,7 @@ jobs:
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: cross-${{ matrix.platform }}
           path: ${{ steps.cross.outputs.install_path }}
@@ -112,7 +112,7 @@ jobs:
         uses: dawidd6/action-get-tag@v1
 
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: cross-linux-musl
           path: /tmp/


### PR DESCRIPTION
Why:
Artifact actions v3 will be deprecated by December 5, 2024.

Impact:
There is a small impact see [here](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). However, the breaking changes do not affect us.